### PR TITLE
[feature] add matrixbuilds with --prefer-lowest and default dependency versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,13 +58,14 @@ jobs:
         run: make analyse
 
   tests:
-    name: "Tests on PHP ${{ matrix.php-version }}"
+    name: "Tests on PHP ${{ matrix.php-version }} ${{ matrix.prefer-lowest }}"
 
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         php-version: [ 8.1 ]
+        prefer-lowest: ['', '--prefer-lowest --prefer-stable']
 
     steps:
       - name: "Checkout"
@@ -77,7 +78,7 @@ jobs:
           coverage: none
 
       - name: "Install dependencies"
-        run: composer install --no-interaction --no-progress --no-suggest --optimize-autoloader
+        run: composer update ${{ matrix.prefer-lowest }} --no-interaction --no-progress --no-suggest --optimize-autoloader
 
       - name: "Run tests"
         run: make tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ 8.1 ]
+        php-version: [ 8.1, 8.2 ]
         prefer-lowest: ['', '--prefer-lowest --prefer-stable']
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,10 +1,6 @@
 on:
   pull_request:
   push:
-    branches:
-      - main
-    tags:
-      - "**"
 
 env:
   MOBILEPAY_API_KEY: ${{ secrets.MOBILEPAY_API_KEY }}
@@ -64,7 +60,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2 ]
+        php-version: [ '8.1', '8.2' ]
         prefer-lowest: ['', '--prefer-lowest --prefer-stable']
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
           coverage: none
 
       - name: "Install dependencies"
-        run: composer install --no-interaction --no-progress --no-suggest --optimize-autoloader
+        run: composer install --no-interaction --no-progress --optimize-autoloader
 
       - name: "Check coding style"
         run: make cs-check
@@ -52,7 +52,7 @@ jobs:
           coverage: none
 
       - name: "Install dependencies"
-        run: composer install --no-interaction --no-progress --no-suggest --optimize-autoloader
+        run: composer install --no-interaction --no-progress --optimize-autoloader
 
       - name: "Run static analysis"
         run: make analyse
@@ -78,7 +78,7 @@ jobs:
           coverage: none
 
       - name: "Install dependencies"
-        run: composer update ${{ matrix.prefer-lowest }} --no-interaction --no-progress --no-suggest --optimize-autoloader
+        run: composer update ${{ matrix.prefer-lowest }} --no-interaction --no-progress --optimize-autoloader
 
       - name: "Run tests"
         run: make tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,6 +59,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         php-version: [ '8.1', '8.2' ]
         prefer-lowest: ['', '--prefer-lowest --prefer-stable']

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ phpunit.xml
 composer.lock
 /coverage
 /vendor
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ phpunit.xml
 composer.lock
 /coverage
 /vendor
-/.idea


### PR DESCRIPTION
to ensure compatibility with lower versions we should run tests with `--prefer-lowest` and switch to `composer update` to install dependencies.