### PR TITLE
mark tests skipped if no api key is provided

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,9 +24,9 @@
         </testsuite>
     </testsuites>
     <php>
-        <env name="MOBILEPAY_API_KEY" value="..."/>
-        <env name="MOBILEPAY_PAYMENTPOINT_ID" value="..."/>
-        <env name="MOBILEPAY_PAYMENT_SOURCE_ID" value="..."/>
-        <env name="MOBILEPAY_USER_ID" value="..."/>
+        <env name="MOBILEPAY_API_KEY" value=""/>
+        <env name="MOBILEPAY_PAYMENTPOINT_ID" value=""/>
+        <env name="MOBILEPAY_PAYMENT_SOURCE_ID" value=""/>
+        <env name="MOBILEPAY_USER_ID" value=""/>
     </php>
 </phpunit>

--- a/src/MobilePay/AppPayment/GatewayTestTrait.php
+++ b/src/MobilePay/AppPayment/GatewayTestTrait.php
@@ -21,6 +21,10 @@ trait GatewayTestTrait
         $apiHost = 'https://api.sandbox.mobilepay.dk';
         $apiKey = (string) getenv('MOBILEPAY_API_KEY');
 
+        if ('' === $apiKey) {
+            static::markTestSkipped('no api key is set, check your MOBILEPAY_API_KEY envvar');
+        }
+
         $httpClient = HttpClient::create();
         $psr18HttpClient = new Psr18Client($httpClient);
 
@@ -37,7 +41,6 @@ trait GatewayTestTrait
                 'reference',
                 'description'
             )
-            ->getPaymentId()
-        ;
+            ->getPaymentId();
     }
 }


### PR DESCRIPTION
since contributors have no api key per default, we should skip tests which require them