### PR TITLE
[feature] make E2E Tests optional if secrets are missing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
         run: make analyse
 
   tests:
-    name: "Tests on PHP ${{ matrix.php-version }} ${{ matrix.prefer-lowest }}"
+    name: "Tests ${{ matrix.php-version }} ${{ matrix.prefer-lowest }}"
 
     runs-on: ubuntu-latest
 
@@ -78,4 +78,8 @@ jobs:
         run: composer update ${{ matrix.prefer-lowest }} --no-interaction --no-progress --optimize-autoloader
 
       - name: "Run tests"
-        run: vendor/bin/phpunit --exclude-group=e2e
+        run: vendor/bin/paratest
+
+      - name: "Run E2E tests"
+        if: ${{ env.MOBILEPAY_API_KEY != '' }}
+        run: vendor/bin/paratest --group=e2e

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
     bootstrap="vendor/autoload.php"
     beStrictAboutCoversAnnotation="true"
     beStrictAboutOutputDuringTests="true"
@@ -23,6 +23,11 @@
             <directory suffix="Test.php">src</directory>
         </testsuite>
     </testsuites>
+    <groups>
+        <exclude>
+            <group>e2e</group>
+        </exclude>
+    </groups>
     <php>
         <env name="MOBILEPAY_API_KEY" value=""/>
         <env name="MOBILEPAY_PAYMENTPOINT_ID" value=""/>


### PR DESCRIPTION
i tinkered around with the E2E tests on forked repositories and moved them into an extra step and excluded them from the default configuration of phpunit.
so on the forked repository we just skip those tests:

![image](https://user-images.githubusercontent.com/1136869/202872509-aedfcfb0-b3f1-48fb-91e5-51707bf229f3.png)

this will make contributing a lot simpler but will require an `make tests-e2e` if we want to run them locally, which should be fine i guess.